### PR TITLE
Redirect without error when there is no expected state in the session

### DIFF
--- a/Demos/02-add-aad-auth/graph-tutorial/app/Http/Controllers/AuthController.php
+++ b/Demos/02-add-aad-auth/graph-tutorial/app/Http/Controllers/AuthController.php
@@ -39,7 +39,13 @@ class AuthController extends Controller
     $request->session()->forget('oauthState');
     $providedState = $request->query('state');
 
-    if (!isset($expectedState) || !isset($providedState) || $expectedState != $providedState) {
+    if (!isset($expectedState)) {
+      // If there is no expected state in the session,
+      // do nothing and redirect to the home page.
+      return redirect('/');
+    }
+
+    if (!isset($providedState) || $expectedState != $providedState) {
       return redirect('/')
         ->with('error', 'Invalid auth state')
         ->with('errorDetail', 'The provided auth state did not match the expected value');

--- a/Demos/03-add-msgraph/graph-tutorial/app/Http/Controllers/AuthController.php
+++ b/Demos/03-add-msgraph/graph-tutorial/app/Http/Controllers/AuthController.php
@@ -39,7 +39,13 @@ class AuthController extends Controller
     $request->session()->forget('oauthState');
     $providedState = $request->query('state');
 
-    if (!isset($expectedState) || !isset($providedState) || $expectedState != $providedState) {
+    if (!isset($expectedState)) {
+      // If there is no expected state in the session,
+      // do nothing and redirect to the home page.
+      return redirect('/');
+    }
+
+    if (!isset($providedState) || $expectedState != $providedState) {
       return redirect('/')
         ->with('error', 'Invalid auth state')
         ->with('errorDetail', 'The provided auth state did not match the expected value');

--- a/tutorial/04-add-aad-auth.md
+++ b/tutorial/04-add-aad-auth.md
@@ -62,7 +62,13 @@ class AuthController extends Controller
     $request->session()->forget('oauthState');
     $providedState = $request->query('state');
 
-    if (!isset($expectedState) || !isset($providedState) || $expectedState != $providedState) {
+    if (!isset($expectedState)) {
+      // If there is no expected state in the session,
+      // do nothing and redirect to the home page.
+      return redirect('/');
+    }
+
+    if (!isset($providedState) || $expectedState != $providedState) {
       return redirect('/')
         ->with('error', 'Invalid auth state')
         ->with('errorDetail', 'The provided auth state did not match the expected value');


### PR DESCRIPTION
In the case where there is no expected state, the app will just redirect back to the home page without taking any action.

Fixes #17