### PR TITLE
Update 02-create-app.md

### DIFF
--- a/tutorial/02-create-app.md
+++ b/tutorial/02-create-app.md
@@ -69,6 +69,22 @@ Before moving on, install some additional packages that you will use later:
     Route::get('/', 'HomeController@welcome');
     ```
 
+1. For Laravel 8, edit './app/Providers/RouteServiceProvider.php' and make sure the namespace variable is present:
+
+```php
+class RouteServiceProvider extends ServiceProvider
+{
+    /**
+     * This namespace is applied to your controller routes.
+     *
+     * In addition, it is set as the URL generator's root namespace.
+     *
+     * @var string
+     */
+    protected $namespace = 'App\Http\Controllers';
+}
+```
+
 1. Save all of your changes and restart the server. Now, the app should look very different.
 
     ![A screenshot of the redesigned home page](./images/create-app-01.png)


### PR DESCRIPTION
There is an additional change needed for newer versions of Laravel to provide the namespace for routing.  This error occurred for me with: Laravel Framework 8.14.0.

It was fixed by following the instruction from MichalOravec, here: https://laracasts.com/discuss/channels/laravel/laravel-8-error-target-class-homecontroller-does-not-exist

"To App/Providers/RouteServiceProvider.php add $namespace"

```
class RouteServiceProvider extends ServiceProvider
{
    /**
     * This namespace is applied to your controller routes.
     *
     * In addition, it is set as the URL generator's root namespace.
     *
     * @var string
     */
    protected $namespace = 'App\Http\Controllers';
}
```

The comment on the linked laracasts page also mentions making sure the boot method uses $namespace, but that was already in place for my version of Laravel, so I am unsure when that is needed.